### PR TITLE
Added support for pure callerID MQTT message

### DIFF
--- a/callattendant/hardware/indicators.py
+++ b/callattendant/hardware/indicators.py
@@ -345,3 +345,14 @@ class MessageCountIndicator(object):
     def close(self):
         if self.seven_seg is not None:
             self.seven_seg.close()
+
+class CallerIDIndicator(object):
+    """
+    The message count indicator displays the number of unplayed messages in the system.
+    """
+    def __init__(self):
+        self.lastCaller = None
+
+    def show_cid(self, caller):
+        self.lastCaller = caller
+        print("{} indicator set to {}".format(self.topic, self.lastCaller["NAME"] + ' ' + self.lastCaller["NMBR"]))

--- a/callattendant/hardware/nullgpio.py
+++ b/callattendant/hardware/nullgpio.py
@@ -118,3 +118,15 @@ class MessageCountIndicator(object):
 
     def close(self):
         pass
+
+class CallerIDIndicator(object):
+    """
+    The message count indicator displays the number of unplayed messages in the system.
+    """
+    def __init__(self):
+        super().__init__()
+        self.lastCaller = None
+
+    def show_cid(self, caller):
+        self.lastCaller = caller
+        print("{} indicator set to {}".format(self.topic, self.lastCaller["NAME"] + ' ' + self.lastCaller["NMBR"]))

--- a/callattendant/screening/calllogger.py
+++ b/callattendant/screening/calllogger.py
@@ -43,6 +43,8 @@ class CallLogger(object):
         self.db.execute(sql, arguments)
         self.db.commit()
 
+        self.caller_indicator.show_cid2(callerid)
+
         # Return the CallLogID
         query = "select last_insert_rowid()"
         result = query_db(self.db, query, (), True)
@@ -62,6 +64,21 @@ class CallLogger(object):
 
         if self.config["DEBUG"]:
             print("Initializing CallLogger")
+
+        #  Hardware subsystem
+        status_indicators = self.config["STATUS_INDICATORS"]
+        if status_indicators == "GPIO":
+            from hardware.indicators import CallerIDIndicator
+            #  Initialize the Caller ID Indicator
+            self.caller_indicator = CallerIDIndicator()
+        elif status_indicators == "MQTT":
+            from hardware.mqttindicators import MQTTCallerIDIndicator
+            #  Initialize the Caller ID Indicator
+            self.caller_indicator = MQTTCallerIDIndicator()
+        elif status_indicators == "NULL":
+            from hardware.nullgpio import CallerIDIndicator
+            #  Initialize the Caller ID Indicator
+            self.caller_indicator = CallerIDIndicator()
 
         # Create the Call_History table if it does not exist
         sql = """CREATE TABLE IF NOT EXISTS CallLog (


### PR DESCRIPTION
I added a methods to send CallerID info to all indicators. Added MQTT message /{mainTopic}/CallerID with JSON payload containing {"name":"CALLER NAME", "number":"555-555-5555"} without timestamp or other decoration.