### PR TITLE
nomorobo updates and additional tests

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -108,8 +108,8 @@ BLOCK_SERVICE = "NOMOROBO"
 # BLOCK_SERVICE_THRESHOLD: The severity level returned by the online service which
 #   is considered spam or nuisance calls. Only values 1 or 2 are accepted.
 # NOMOROBO:
-#   1 = might be spam (caller is "Political", "Charity", or "Debt Collector"),
-#   2 = Spam - marked as "Do Not Answer",
+#   1 = Caller is identified by NOMOROBO as a Robocall.
+#   2 = Spam - marked as a scam, or a robocaller with "Severe" Call Activity
 # SHOULDIANSWER:
 #   1 = (not used - further analysis of the score in "reviews' section warranted)
 #   2 = Spam - marked as "Negative"

--- a/callattendant/screening/callscreener.py
+++ b/callattendant/screening/callscreener.py
@@ -95,10 +95,10 @@ class CallScreener(object):
                 if self._blockservice is not None:
                     print(">> Checking block service...")
                     result = self._blockservice.lookup_number(number)
+                    reason = "{} with score {}".format(result["reason"], result["score"])
+                    if self.config["DEBUG"]:
+                        print(">>> {}".format(reason))
                     if result["spam"]:
-                        reason = "{} with score {}".format(result["reason"], result["score"])
-                        if self.config["DEBUG"]:
-                            print(">>> {}".format(reason))
                         self.blacklist_caller(callerid, reason)
                         return True, (reason, None)
 
@@ -125,11 +125,13 @@ class CallScreener(object):
 
         bs = config["BLOCK_SERVICE"].upper()
         if bs == "NOMOROBO":
-            # Set blocking threshold to 1 to filter nuisance calls
             self._blockservice = NomoroboService(config["BLOCK_SERVICE_THRESHOLD"])
+            print("NomoroboService Initialized as CallScreener") if self.config["DEBUG"] else None
         elif bs == "SHOULDIANSWER":
             self._blockservice = ShouldIAnswer(config["BLOCK_SERVICE_THRESHOLD"])
+            print("ShouldIAnswer Initialized as CallScreener") if self.config["DEBUG"] else None
         else:
+            print("No 3rd Party CallScreener Initialized") if self.config["DEBUG"] else None
             self._blockservice = None
 
         # Load number and name patterns into config vars

--- a/callattendant/screening/nomorobo.py
+++ b/callattendant/screening/nomorobo.py
@@ -43,13 +43,25 @@ class NomoroboService(object):
 
         score = 0  # = no spam
 
-        positions = soup.findAll(class_="profile-position")
-        if len(positions) > 0:
-            position = positions[0].get_text()
-            if position.upper().find("DO NOT ANSWER") > -1:
-                score = 2  # = is spam
-            else:
-                score = 1  # = might be spam (caller is "Political", "Charity", or "Debt Collector")
+        prewords = soup.findAll(class_="profile-preword")
+        if len(prewords) > 0:
+            preword = prewords[0].get_text()
+            if preword.upper().find("UNKNOWN") > -1:
+                score = 0
+            elif preword.upper().find("SCAM") > -1:
+                score = 2
+            elif preword.upper().find("ROBOCALL") > -1:
+                # This is a robocaller; look for severity for escalation
+                profile_list = soup.findAll(class_="profile-list")
+                if len(profile_list) > 0:
+                    label = profile_list[0].find(class_="label")
+                    if label:
+                        if label.get_text().upper().find("SEVERE") > -1:
+                            score = 2
+                        else:
+                            score = 1
+                else:
+                    score = 1
 
         reason = ""
         titles = soup.findAll(class_="profile-title")
@@ -58,11 +70,6 @@ class NomoroboService(object):
             # cleanup text and remove excess whitespace
             reason = reason.replace("\n", "").strip(" ")
             reason = re.sub('\\s+', ' ', reason)
-            # TODO: if score == 1, check for "Political", "Charity", and/or "Debt Collector"
-            # in the reason and adjust the score if appropriate
-            if score == 1:
-                if reason.upper().find("UNKNOWN CALLER") > -1:
-                    score = 0
 
         spam = False if score < self.spam_threshold else True
 

--- a/tests/test_nomorobo.py
+++ b/tests/test_nomorobo.py
@@ -25,18 +25,47 @@
 
 from pprint import pprint
 
-import pytest
-
-from callattendant.app import make_config
 from callattendant.screening.nomorobo import NomoroboService
 
 
-def test_lookup():
+def test_5622862616_should_score_1():
     nomorobo = NomoroboService()
     result = nomorobo.lookup_number("5622862616")
     pprint(result)
-    assert result["spam"]
+    assert result["score"] == 1
 
+def test_8886727156_should_be_spam():
+    nomorobo = NomoroboService()
+    result = nomorobo.lookup_number("8886727156")
+    pprint(result)
+    assert result["spam"] is True
+
+def test_8886727156_should_score_2():
+    nomorobo = NomoroboService()
+    result = nomorobo.lookup_number("8886727156")
+    pprint(result)
+    assert result["score"] == 2
+
+def test_404_not_marked_as_spam():
+    nomorobo = NomoroboService()
     result = nomorobo.lookup_number("1234567890")
     pprint(result)
-    assert not result.get("spam")
+    assert result["spam"] is False
+
+def test_9725551356_is_unknown():
+    nomorobo = NomoroboService()
+    result = nomorobo.lookup_number("9725551356")
+    pprint(result)
+    assert result["score"] == 0
+
+def test_9725551356_is_not_spam():
+    nomorobo = NomoroboService()
+    result = nomorobo.lookup_number("9725551356")
+    pprint(result)
+    assert result["spam"] is False
+
+def test_8554188397_should_score_2():
+    nomorobo = NomoroboService()
+    result = nomorobo.lookup_number("8554188397")
+    pprint(result)
+    assert result["score"] == 2

--- a/tests/test_shouldianswer.py
+++ b/tests/test_shouldianswer.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pprint import pprint
+
+from callattendant.screening.shouldianswer import ShouldIAnswer
+
+
+def test_8886727156_should_score_0():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("8886727156")
+    pprint(result)
+    assert result["score"] == 0
+
+
+def test_8886727156_is_not_spam():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("8886727156")
+    pprint(result)
+    assert result["spam"] is not True
+
+
+def test_1234567890_not_marked_as_spam():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("1234567890")
+    pprint(result)
+    assert result["spam"] is False
+
+
+def test_9725551356_is_unknown():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("9725551356")
+    pprint(result)
+    assert result["score"] == 0
+
+
+def test_9725551356_is_not_spam():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("9725551356")
+    pprint(result)
+    assert result["spam"] is False
+
+
+def test_8554188397_is_spam():
+    shouldIAnswer = ShouldIAnswer()
+    result = shouldIAnswer.lookup_number("8554188397")
+    pprint(result)
+    assert result["spam"]


### PR DESCRIPTION
Update for Issue #80 

This works the following ways:

If `profile-preword` shows as Unknown Caller, score is 0
If `profile-preword` shows Scam, score is 2
If `profile-preword` shows Robocall, then:
 - If the label shows 'Severe' then the score is a 2
 - If the label does not exist or is not `Severe` (`Low` as an example) then the score is a 1.
   
Also added additional tests with sample numbers, however these tests may age since they assume live data on Nomorobo remains valid. (Existing tests were failing suggesting that indeed the NOMOROBO response had changed)