### PR TITLE
Fixed / Refactored (non-CI) Unit tests to run green based on current functionality

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,11 +58,13 @@ def app(mocker):
     config["SCREENED_ACTIONS"] = ("answer", "greeting", "record_message")
     config["SCREENED_RINGS_BEFORE_ANSWER"] = 0
     config["PERMITTED_ACTIONS"] = ("ignore",)
-    config["PERMITTED_RINGS_BEFORE_ANSWER"] = 4
+    config["PERMITTED_RINGS_BEFORE_ANSWER"] = 0
+    config["SREENING_MODE"] = ("whitelist", "blacklist")
 
     # Mock the hardware interfaces
     mocker.patch("hardware.modem.Modem._open_serial_port", return_value=True)
     mocker.patch("hardware.modem.Modem.start", return_value=True)
+    mocker.patch("hardware.modem.Modem.stop", return_value=True)
     mocker.patch("hardware.modem.Modem.pick_up", return_value=True)
     mocker.patch("hardware.modem.Modem.hang_up", return_value=True)
     mocker.patch("hardware.modem.Modem.play_audio", return_value=True)
@@ -84,6 +86,9 @@ def app(mocker):
     mocker.patch("hardware.indicators.RingIndicator.__init__", return_value=None)
     mocker.patch("hardware.indicators.RingIndicator.blink")
     mocker.patch("hardware.indicators.RingIndicator.close")
+
+    # Mock signal.signal to avoid errors in test threads
+    mocker.patch("signal.signal", return_value=None)
 
     def mock_is_whitelisted(caller):
         if caller["NAME"] in ["CALLER1", "CALLER3"]:
@@ -175,12 +180,12 @@ def test_ignore_permitted(app):
     ignore_call_called = False
 
     app.handle_caller(caller1)   # Queue a permitted caller with 4 rings
-    time.sleep(15)
+    time.sleep(2)
 
     assert ignore_call_called
 
     # Stop the run thread
-    app._stop_event.set()
+    app.set_stop_flag()
 
 
 def test_answer_blocked(app):
@@ -199,7 +204,7 @@ def test_answer_blocked(app):
     assert answer_call_called
 
     # Stop the run thread
-    app._stop_event.set()
+    app.set_stop_flag()
 
 
 def test_answer_screened(app):
@@ -218,7 +223,7 @@ def test_answer_screened(app):
     assert answer_call_called
 
     # Stop the run thread
-    app._stop_event.set()
+    app.set_stop_flag()
 
 
 def test_queued_call(app):
@@ -245,7 +250,7 @@ def test_queued_call(app):
     assert answer_call_called
 
     # Stop the run thread
-    app._stop_event.set()
+    app.set_stop_flag()
 
 
 def test_answer_call_no_actions(app, mocker):

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -24,22 +24,22 @@
 #  SOFTWARE.
 
 import sqlite3
-from pprint import pprint
 
 import pytest
 
 from callattendant.screening.blacklist import Blacklist
 
+BRUCE = {"NAME": "Bruce", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope='function')
 def blacklist():
-
     # Create the test db in RAM
     db = sqlite3.connect(":memory:")
 
     # Mock the application config, which is a dict-based object
     config = {}
-    config['DEBUG'] = True
+    config['DEBUG'] = False
     config['TESTING'] = True
 
     # Create the blacklist to be tested
@@ -48,68 +48,54 @@ def blacklist():
     return blacklist
 
 
-def test_add_caller(blacklist):
-    # Add a record
-    callerid = {"NAME": "Bruce", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600", }
-    assert blacklist.add_caller(callerid, "Test")
+def test_can_add_caller_to_blacklist(blacklist):
+    assert blacklist.add_caller(BRUCE, "Test")
 
 
-def test_check_number(blacklist):
-    number = "1234567890"
+def test_adding_duplicate_fails(blacklist):
+    assert blacklist.add_caller(BRUCE, "Test Add")
+    assert blacklist.add_caller(BRUCE, "Test Update") is False
 
-    is_blacklisted, reason = blacklist.check_number(number)
 
-    assert is_blacklisted
-    assert reason == "Test"
+def test_check_number_returns_correct_reason(blacklist):
+    test_reason = "SpecificReason"
+    blacklist.add_caller(BRUCE, test_reason)
+    is_blacklisted, (reason, name) = blacklist.check_number(BRUCE.get("NMBR"))
 
-    number = "1111111111"
+    assert is_blacklisted is True
+    assert reason == test_reason
 
-    is_blacklisted, reason = blacklist.check_number(number)
 
+def test_check_number_returns_none_if_not_present(blacklist):
+    blacklist.add_caller(BRUCE, "Test Reason")
+    test_number = "1111111111"
+    is_blacklisted, reason = blacklist.check_number(test_number)
     assert not is_blacklisted
 
 
-def test_get_number(blacklist):
-    number = "1234567890"
+def test_get_number_returns_entry(blacklist):
+    test_reason = "ABC12345"
+    blacklist.add_caller(BRUCE, test_reason)
+    caller = blacklist.get_number(BRUCE.get("NMBR"))
+    assert caller[0][0] == BRUCE.get("NMBR")
+    assert caller[0][1] == BRUCE.get("NAME")
+    assert caller[0][2] == test_reason
 
-    caller = blacklist.get_number(number)
-    pprint(caller)
 
-    assert caller[0][0] == number
+def test_update_number(blacklist):
+    test_reason = "ABC12345"
+    new_reason = "XYZ98765"
+    new_name = "Joe"
+    blacklist.add_caller(BRUCE, test_reason)
+    blacklist.update_number(BRUCE.get("NMBR"), new_name, new_reason)
+    caller = blacklist.get_number(BRUCE.get("NMBR"))
+    assert caller[0][0] == BRUCE.get("NMBR")
+    assert caller[0][1] == new_name
+    assert caller[0][2] == new_reason
 
 
-def test_multiple(blacklist):
-    new_caller = {"NAME": "New Caller", "NMBR": "12312351234", "DATE": "1012", "TIME": "0600"}
-    number = new_caller["NMBR"]
-    name = new_caller["NAME"]
-    reason = "Test"
-    pprint(new_caller)
-
-    assert blacklist.add_caller(new_caller, reason)
-
-    caller = blacklist.get_number(number)
-    pprint(caller)
-
-    assert caller[0][0] == number
-    assert caller[0][1] == name
-    assert caller[0][2] == reason
-
-    name = "Joe"
-    reason = "Confirm"
-
-    assert blacklist.update_number(number, name, reason)
-
-    caller = blacklist.get_number(number)
-    pprint(caller)
-
-    assert caller[0][0] == number
-    assert caller[0][1] == name
-    assert caller[0][2] == reason
-
-    assert blacklist.remove_number(number)
-
-    is_blacklisted, reason = blacklist.check_number(number)
-    assert not is_blacklisted
-
-    caller = blacklist.get_number(number)
-    pprint(caller)
+def test_removing_number(blacklist):
+    blacklist.add_caller(BRUCE, "Test Reason")
+    assert len(blacklist.get_number(BRUCE.get("NMBR"))) == 1
+    blacklist.remove_number(BRUCE.get("NMBR"))
+    assert len(blacklist.get_number(BRUCE.get("NMBR"))) == 0

--- a/tests/test_calllogger.py
+++ b/tests/test_calllogger.py
@@ -29,7 +29,7 @@ import pytest
 from callattendant.screening.calllogger import CallLogger
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def calllogger():
 
     # Create the test db in RAM
@@ -52,7 +52,7 @@ def test_add_caller(calllogger):
     callerid = {
         "NAME": "Bruce",
         "NMBR": "1234567890",
-        "DATE": "1012",
+        "DATE": "10122023",
         "TIME": "0600",
     }
 

--- a/tests/test_callscreener.py
+++ b/tests/test_callscreener.py
@@ -29,7 +29,6 @@ import pytest
 from callattendant.config import Config
 from callattendant.screening.callscreener import CallScreener
 
-
 # Create a blocked caller
 caller1 = {"NAME": "CALLER1", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
 # Create a permitted caller
@@ -44,11 +43,12 @@ caller5 = {"NAME": "CALLER5", "NMBR": "P", "DATE": "1012", "TIME": "0600"}
 caller6 = {"NAME": "JOHN DOE", "NMBR": "0987654321", "DATE": "1012", "TIME": "0600"}
 # Create a unique number (permitted number pattern match)
 caller7 = {"NAME": "CALLER7", "NMBR": "09876543210", "DATE": "1012", "TIME": "0600"}
+# ShouldIAnswer Spam
+caller8 = {"NAME": "CALLER8", "NMBR": "8554188397", "DATE": "1012", "TIME": "0600"}
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def screener():
-
     # Create the test db in RAM
     db = sqlite3.connect(":memory:")
 
@@ -56,24 +56,22 @@ def screener():
     config = Config()
     config['DEBUG'] = True
     config['TESTING'] = True
-    config['BLOCK_NAME_PATTERNS'] = {
-        "V[0-9]{15}": "Telemarketer Caller ID",
-    }
-    config['BLOCK_NUMBER_PATTERNS'] = {
-        "P": "Private number",
-    }
-    config['PERMIT_NAME_PATTERNS'] = {
-        ".*DOE": "Anyone",
-    }
-    config['PERMIT_NUMBER_PATTERNS'] = {
-        "987654": "Anyone",
-    }
+
+    config['BLOCK_SERVICE_THRESHOLD'] = 1
+    config['BLOCK_SERVICE'] = "NOMOROBO"
     # Create the blacklist to be tested
     screener = CallScreener(db, config)
+
+    screener.config['CALLERID_PATTERNS'] = {
+        'blocknames': {'V[0-9]{15}': "Telemarketer Caller ID"},
+        'blocknumbers': {'P': "Private Number"},
+        'permitnames': {'.*DOE': "Anyone"},
+        'permitnumbers': {'987654': "Anyone"}
+    }
     # Add a record to the blacklist
-    screener._blacklist.add_caller(caller1)
+    screener.blacklist_caller(caller1, "Test Blacklist")
     # Add a record to the whitelist
-    screener._whitelist.add_caller(caller2)
+    screener.whitelist_caller(caller2, "Test Whitelist")
 
     return screener
 
@@ -104,8 +102,15 @@ def test_blocked_name_pattern(screener):
 
 
 def test_is_blacklisted_by_nomorobo(screener):
+    screener.config['BLOCK_SERVICE'] = "NOMOROBO"
     is_blacklisted, reason = screener.is_blacklisted(caller4)
     assert is_blacklisted, "caller4 should be blocked by nomorobo"
+
+
+def test_is_blacklisted_by_shouldianswer(screener):
+    screener.config['BLOCK_SERVICE'] = "SHOULDIANSWER"
+    is_blacklisted, reason = screener.is_blacklisted(caller8)
+    assert is_blacklisted, "caller8 should be blocked by nomorobo"
 
 
 def test_blocked_number_pattern(screener):

--- a/tests/test_nomorobo.py
+++ b/tests/test_nomorobo.py
@@ -25,49 +25,49 @@
 
 from pprint import pprint
 
+import pytest
+
 from callattendant.screening.nomorobo import NomoroboService
 
 test_username = "<your-username>"
 test_password = "<your-password>"
 
-def test_5622862616_should_score_1():
+@pytest.fixture(scope='function')
+def nomorobo():
     nomorobo = NomoroboService(test_username, test_password)
+    return nomorobo
+
+def test_5622862616_should_score_1(nomorobo):
     result = nomorobo.lookup_number("5622862616")
     pprint(result)
     assert result["score"] == 1
 
-def test_8886727156_should_be_spam():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_8886727156_should_be_spam(nomorobo):
     result = nomorobo.lookup_number("8886727156")
     pprint(result)
     assert result["spam"] is True
 
-def test_8886727156_should_score_2():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_8886727156_should_score_2(nomorobo):
     result = nomorobo.lookup_number("8886727156")
     pprint(result)
     assert result["score"] == 2
 
-def test_404_not_marked_as_spam():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_404_not_marked_as_spam(nomorobo):
     result = nomorobo.lookup_number("1234567890")
     pprint(result)
     assert result["spam"] is False
 
-def test_9725551356_is_unknown():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_9725551356_is_unknown(nomorobo):
     result = nomorobo.lookup_number("9725551356")
     pprint(result)
     assert result["score"] == 0
 
-def test_9725551356_is_not_spam():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_9725551356_is_not_spam(nomorobo):
     result = nomorobo.lookup_number("9725551356")
     pprint(result)
     assert result["spam"] is False
 
-def test_8554188397_should_score_2():
-    nomorobo = NomoroboService(test_username, test_password)
+def test_8554188397_should_score_2(nomorobo):
     result = nomorobo.lookup_number("8554188397")
     pprint(result)
     assert result["score"] == 2

--- a/tests/test_shouldianswer.py
+++ b/tests/test_shouldianswer.py
@@ -3,46 +3,48 @@
 
 from pprint import pprint
 
+import pytest
+
 from callattendant.screening.shouldianswer import ShouldIAnswer
 
 
-def test_8886727156_should_score_0():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("8886727156")
+@pytest.fixture(scope='function')
+def should_i_answer():
+    should_i_answer = ShouldIAnswer()
+    return should_i_answer
+
+
+def test_8886727156_should_score_0(should_i_answer):
+    result = should_i_answer.lookup_number("8886727156")
     pprint(result)
     assert result["score"] == 0
 
 
-def test_8886727156_is_not_spam():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("8886727156")
+def test_8886727156_is_not_spam(should_i_answer):
+    result = should_i_answer.lookup_number("8886727156")
     pprint(result)
     assert result["spam"] is not True
 
 
-def test_1234567890_not_marked_as_spam():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("1234567890")
+def test_1234567890_not_marked_as_spam(should_i_answer):
+    result = should_i_answer.lookup_number("1234567890")
     pprint(result)
     assert result["spam"] is False
 
 
-def test_9725551356_is_unknown():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("9725551356")
+def test_9725551356_is_unknown(should_i_answer):
+    result = should_i_answer.lookup_number("9725551356")
     pprint(result)
     assert result["score"] == 0
 
 
-def test_9725551356_is_not_spam():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("9725551356")
+def test_9725551356_is_not_spam(should_i_answer):
+    result = should_i_answer.lookup_number("9725551356")
     pprint(result)
     assert result["spam"] is False
 
 
-def test_8554188397_is_spam():
-    shouldIAnswer = ShouldIAnswer()
-    result = shouldIAnswer.lookup_number("8554188397")
+def test_8554188397_is_spam(should_i_answer):
+    result = should_i_answer.lookup_number("8554188397")
     pprint(result)
     assert result["spam"]

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -47,6 +47,11 @@ def myapp():
     app.secret_key = get_random_string()
     with app.app_context():
 
+        dummy_nextcall = type("DummyNextCall", (), {
+            "is_next_call_permitted": lambda self: False,
+            "toggle_next_call_permitted": lambda self: None
+        })()
+
         master_config = {
             "DB_FILE": db_path,
             "PHONE_DISPLAY_FORMAT": "###-###-####",
@@ -54,6 +59,7 @@ def myapp():
         }
 
         app.config['MASTER_CONFIG'] = master_config
+        app.config["NEXTCALL"] = dummy_nextcall
         app.config["TESTING"] = True
         app.config["DEBUG"] = True
 

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -24,22 +24,22 @@
 #  SOFTWARE.
 
 import sqlite3
-from pprint import pprint
 
 import pytest
 
 from callattendant.screening.whitelist import Whitelist
 
+BRUCE = {"NAME": "Bruce", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope='function')
 def whitelist():
-
     # Create the test db in RAM
     db = sqlite3.connect(":memory:")
 
     # Mock the application config, which is a dict-based object
     config = {}
-    config['DEBUG'] = True
+    config['DEBUG'] = False
     config['TESTING'] = True
 
     # Create the whitelist to be tested
@@ -48,68 +48,60 @@ def whitelist():
     return whitelist
 
 
-def test_add_caller(whitelist):
-    # Add a record
-    callerid = {"NAME": "Bruce", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
-    assert whitelist.add_caller(callerid, "Test")
+def test_can_add_caller_to_whitelist(whitelist):
+    assert whitelist.add_caller(BRUCE, "Test Add")
 
 
-def test_check_number(whitelist):
-    number = "1234567890"
+def test_adding_duplicate_fails(whitelist):
+    assert whitelist.add_caller(BRUCE, "Test Add")
+    assert whitelist.add_caller(BRUCE, "Test Update") is False
 
-    is_whitelisted, reason = whitelist.check_number(number)
 
-    assert is_whitelisted
-    assert reason == "Test"
+def test_check_number_returns_correct_reason(whitelist):
+    test_reason = "SpecificReason"
+    whitelist.add_caller(BRUCE, test_reason)
+    is_whitelisted, (reason, name) = whitelist.check_number(BRUCE.get("NMBR"))
+    assert is_whitelisted is True
+    assert reason == test_reason
 
-    number = "1111111111"
 
-    is_whitelisted, reason = whitelist.check_number(number)
-
+def test_check_number_returns_none_if_not_present(whitelist):
+    whitelist.add_caller(BRUCE, "Test Reason")
+    test_number = "1111111111"
+    is_whitelisted, reason = whitelist.check_number(test_number)
     assert not is_whitelisted
 
 
-def test_get_number(whitelist):
-    number = "1234567890"
-
-    caller = whitelist.get_number(number)
-    pprint(caller)
-
-    assert caller[0][0] == number
+def test_check_number_returns_no_reason_if_not_present(whitelist):
+    whitelist.add_caller(BRUCE, "Test Reason")
+    test_number = "1111111111"
+    is_whitelisted, reason = whitelist.check_number(test_number)
+    assert reason is None
 
 
-def test_multiple(whitelist):
-    new_caller = {"NAME": "New Caller", "NMBR": "12312351234", "DATE": "1012", "TIME": "0600"}
-    number = new_caller["NMBR"]
-    name = new_caller["NAME"]
-    reason = "Test"
-    pprint(new_caller)
+def test_get_number_returns_entry(whitelist):
+    test_reason = "ABC12345"
+    whitelist.add_caller(BRUCE, test_reason)
+    caller = whitelist.get_number(BRUCE.get("NMBR"))
+    assert caller[0][0] == BRUCE.get("NMBR")
+    assert caller[0][1] == BRUCE.get("NAME")
+    assert caller[0][2] == test_reason
 
-    assert whitelist.add_caller(new_caller, reason)
 
-    caller = whitelist.get_number(number)
-    pprint(caller)
+def test_update_number(whitelist):
+    test_reason = "ABC12345"
+    new_reason = "XYZ98765"
+    new_name = "Joe"
+    whitelist.add_caller(BRUCE, test_reason)
+    whitelist.update_number(BRUCE.get("NMBR"), new_name, new_reason)
+    caller = whitelist.get_number(BRUCE.get("NMBR"))
+    assert caller[0][0] == BRUCE.get("NMBR")
+    assert caller[0][1] == new_name
+    assert caller[0][2] == new_reason
 
-    assert caller[0][0] == number
-    assert caller[0][1] == name
-    assert caller[0][2] == reason
 
-    name = "Joe"
-    reason = "Confirm"
-
-    assert whitelist.update_number(number, name, reason)
-
-    caller = whitelist.get_number(number)
-    pprint(caller)
-
-    assert caller[0][0] == number
-    assert caller[0][1] == name
-    assert caller[0][2] == reason
-
-    assert whitelist.remove_number(number)
-
-    is_whitelisted, reason = whitelist.check_number(number)
-    assert not is_whitelisted
-
-    caller = whitelist.get_number(number)
-    pprint(caller)
+def test_removing_number(whitelist):
+    whitelist.add_caller(BRUCE, "Test Reason")
+    assert len(whitelist.get_number(BRUCE.get("NMBR"))) == 1
+    whitelist.remove_number(BRUCE.get("NMBR"))
+    assert len(whitelist.get_number(BRUCE.get("NMBR"))) == 0


### PR DESCRIPTION
Tests should now run green with the exception of the `test_webapp` and CI / Integration Tests.