### PR TITLE
Update app.cfg.example to fix IPv6 enablement.

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -26,7 +26,7 @@ MODEM_DEVICE = ""
 #   See README.md notes regarding caller-id enable for Dell RD02-D400 modems.
 OPTIONAL_MODEM_INIT = ""
 
-# Web UI options: HOST can be set to a specific IP address or "::" to include IPv6
+# Web UI options: HOST can be set to a specific IP address or "*" to include IPv6
 HOST = "0.0.0.0"
 PORT = 5000
 


### PR DESCRIPTION
Fixes: https://github.com/thess/callattendant/issues/87

As per https://docs.pylonsproject.org/projects/waitress/en/latest/usage.html the host needs to be set to "*" to enable IPv6.

Setting the host to "::" only allows access on IPv6,